### PR TITLE
fix: restore reliable startup with versioned script fallback

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,6 +25,8 @@ function start(){
   ctx = canvas.getContext('2d');
   resize();
   drawLoading();
+  const l=document.getElementById('loading-screen');
+  if(l) l.remove();
   try{
     init();
     last = performance.now();

--- a/index.html
+++ b/index.html
@@ -1,27 +1,58 @@
 <!doctype html><html><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Platformer</title>
+<style>
+body{margin:0;background:#0e0f14;color:#eee;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial}
+#loading-screen{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;font-size:20px}
+#game{display:block;width:100vw;height:100vh}
+#error-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);color:#fff;padding:16px;white-space:pre-wrap;overflow:auto;display:none}
+</style>
+<link id="main-style" rel="stylesheet" href="styles.css"/>
 <script src="version.js"></script>
 <script>
+function showError(err){
+  const o=document.getElementById('error-overlay');
+  o.textContent=(err&&err.stack)||err;
+  o.style.display='block';
+}
+window.onerror=(msg,src,line,col,err)=>{showError(err||msg);};
+window.onunhandledrejection=e=>{showError(e.reason);};
 (function(){
-  document.title = `Platformer — v${self.GAME_VERSION}`;
-  const addVersion = u => self.GAME_VERSION ? `${u}?v=${self.GAME_VERSION}` : u;
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = addVersion('styles.css');
-  document.head.appendChild(link);
-  const script = document.createElement('script');
-  script.src = addVersion('game.js');
-  script.defer = true;
-  document.head.appendChild(script);
-  if('serviceWorker' in navigator){
-    navigator.serviceWorker.register(addVersion('sw.js')).then(()=>{
-      navigator.serviceWorker.addEventListener('controllerchange', ()=>location.reload());
+  try{
+    document.title=`Platformer — v${self.GAME_VERSION}`;
+    const addVersion=u=>self.GAME_VERSION?`${u}?v=${self.GAME_VERSION}`:u;
+    const link=document.getElementById('main-style');
+    link.href=addVersion('styles.css');
+    function loadScript(src){
+      return new Promise((res,rej)=>{
+        const s=document.createElement('script');
+        s.src=src;
+        s.onload=res;
+        s.onerror=()=>rej(new Error('Failed to load '+src));
+        document.head.appendChild(s);
+      });
+    }
+    loadScript(addVersion('game.js')).catch(err=>{
+      console.error(err);
+      showError(err);
+      return loadScript('game.js');
+    }).catch(err=>{
+      console.error(err);
+      showError(err);
     });
-  }
+    if('serviceWorker' in navigator){
+      navigator.serviceWorker.register(addVersion('sw.js')).then(()=>{
+        navigator.serviceWorker.addEventListener('controllerchange',()=>location.reload());
+      }).catch(err=>{
+        console.error(err);
+        showError(err);
+      });
+    }
+  }catch(e){showError(e);}
 })();
 </script>
 </head><body>
+<div id="loading-screen">Loading…</div>
 <canvas id="game"></canvas>
-<div id="error-overlay" style="display:none"></div>
+<div id="error-overlay"></div>
 </body></html>


### PR DESCRIPTION
## Summary
- render a "Loading…" screen immediately and remove it after init
- load versioned `game.js` with error handling and fallback
- show startup errors in an overlay; keep version from `version.js`

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d522c4b88325962540686d0ad063