### PR TITLE
Hide loading overlay after first frame

### DIFF
--- a/game.js
+++ b/game.js
@@ -6,12 +6,19 @@ let canvas, ctx, last=0, acc=0, fps=60, fpsTime=0, frameCount=0;
 const dt = 1/60;
 let safeMode = false;
 let score = 0;
+let isReady = false;
+let loader = null;
 
 const keys = {left:false,right:false,up:false};
 
 const world = { platforms:[], coins:[], player:null, camera:{x:0,y:0,shake:0,shakeTime:0} };
 
 function showError(err){
+  if(loader) loader.style.display = 'none';
+  else{
+    const l = document.getElementById('loading-screen');
+    if(l) l.style.display = 'none';
+  }
   const o = document.getElementById('error-overlay');
   o.textContent = (err && err.stack) || err;
   o.style.display = 'block';
@@ -24,9 +31,8 @@ function start(){
   canvas = document.getElementById('game');
   ctx = canvas.getContext('2d');
   resize();
+  loader = document.getElementById('loading-screen');
   drawLoading();
-  const l=document.getElementById('loading-screen');
-  if(l) l.remove();
   try{
     init();
     last = performance.now();
@@ -35,6 +41,7 @@ function start(){
 }
 
 function drawLoading(){
+  if(isReady) return;
   drawBackground(0);
   ctx.fillStyle = '#fff';
   ctx.font = '20px sans-serif';
@@ -101,6 +108,10 @@ function loop(t){
     if(t - fpsTime > 1000){ fps = frameCount; frameCount=0; fpsTime=t; if(fps<30) safeMode=true; }
     while(acc>dt){ update(dt); acc-=dt; }
     render();
+    if(!isReady){
+      isReady = true;
+      if(loader) loader.style.display = 'none';
+    }
     requestAnimationFrame(loop);
   }catch(e){ showError(e); }
 }

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@ body{margin:0;background:#0e0f14;color:#eee;font-family:system-ui,-apple-system,
 <script src="version.js"></script>
 <script>
 function showError(err){
+  const l=document.getElementById('loading-screen');
+  if(l) l.style.display='none';
   const o=document.getElementById('error-overlay');
   o.textContent=(err&&err.stack)||err;
   o.style.display='block';


### PR DESCRIPTION
## Summary
- hide DOM loading overlay after the first successful frame
- ensure error overlay replaces loading screen on exceptions

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d75fcac88325a15e34f6ef8449bb