### PR TITLE
Fix boot hang in v0.0.4

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,4 +1,5 @@
 const GAME_VERSION = self.GAME_VERSION;
+if(self.BOOT) self.BOOT.script = true;
 
 function asArray(v){ return Array.isArray(v)?v:[]; }
 
@@ -13,21 +14,10 @@ const keys = {left:false,right:false,up:false};
 
 const world = { platforms:[], coins:[], player:null, camera:{x:0,y:0,shake:0,shakeTime:0} };
 
-function showError(err){
-  if(loader) loader.style.display = 'none';
-  else{
-    const l = document.getElementById('loading-screen');
-    if(l) l.style.display = 'none';
-  }
-  const o = document.getElementById('error-overlay');
-  o.textContent = (err && err.stack) || err;
-  o.style.display = 'block';
-}
-
-window.onerror = (msg,src,line,col,err)=>{ showError(err||msg); };
-window.onunhandledrejection = e=>{ showError(e.reason); };
-
+let started=false;
 function start(){
+  if(started) return;
+  started=true;
   canvas = document.getElementById('game');
   ctx = canvas.getContext('2d');
   resize();
@@ -35,8 +25,10 @@ function start(){
   drawLoading();
   try{
     init();
+    if(self.BOOT) self.BOOT.init=true;
     last = performance.now();
     requestAnimationFrame(loop);
+    if(self.BOOT) self.BOOT.loop=true;
   }catch(e){ showError(e); }
 }
 
@@ -48,7 +40,7 @@ function drawLoading(){
   ctx.fillText('Loading...',20,40);
 }
 
-window.addEventListener('DOMContentLoaded', start);
+if(document.readyState==='loading') window.addEventListener('DOMContentLoaded', start, {once:true}); else start();
 window.addEventListener('resize', resize);
 
 function resize(){
@@ -111,6 +103,10 @@ function loop(t){
     if(!isReady){
       isReady = true;
       if(loader) loader.style.display = 'none';
+      if(self.BOOT){
+        self.BOOT.frame = true;
+        if(self.BOOT.watchdog) clearTimeout(self.BOOT.watchdog);
+      }
     }
     requestAnimationFrame(loop);
   }catch(e){ showError(e); }

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@ body{margin:0;background:#0e0f14;color:#eee;font-family:system-ui,-apple-system,
 <script src="version.js"></script>
 <script>
 function showError(err){
+  if(self.BOOT && self.BOOT.watchdog) clearTimeout(self.BOOT.watchdog);
   const l=document.getElementById('loading-screen');
   if(l) l.style.display='none';
   const o=document.getElementById('error-overlay');
@@ -21,8 +22,16 @@ window.onerror=(msg,src,line,col,err)=>{showError(err||msg);};
 window.onunhandledrejection=e=>{showError(e.reason);};
 (function(){
   try{
+    if(typeof self.GAME_VERSION==='undefined') throw new Error('version.js failed to load');
     document.title=`Platformer — v${self.GAME_VERSION}`;
     const addVersion=u=>self.GAME_VERSION?`${u}?v=${self.GAME_VERSION}`:u;
+    self.BOOT={script:false,init:false,loop:false,frame:false};
+    self.BOOT.watchdog=setTimeout(()=>{
+      if(!self.BOOT.frame){
+        const reason=!self.BOOT.script?'version/import':!self.BOOT.init?'world/input init':!self.BOOT.loop?'loop start':'first frame render';
+        showError('Startup timeout: '+reason);
+      }
+    },2000);
     const link=document.getElementById('main-style');
     link.href=addVersion('styles.css');
     function loadScript(src){
@@ -34,21 +43,20 @@ window.onunhandledrejection=e=>{showError(e.reason);};
         document.head.appendChild(s);
       });
     }
-    loadScript(addVersion('game.js')).catch(err=>{
-      console.error(err);
-      showError(err);
-      return loadScript('game.js');
-    }).catch(err=>{
-      console.error(err);
-      showError(err);
-    });
-    if('serviceWorker' in navigator){
-      navigator.serviceWorker.register(addVersion('sw.js')).then(()=>{
-        navigator.serviceWorker.addEventListener('controllerchange',()=>location.reload());
-      }).catch(err=>{
+    loadScript(addVersion('game.js'))
+      .catch(err=>{
         console.error(err);
-        showError(err);
+        return loadScript('game.js');
+      })
+      .then(()=>{ self.BOOT.script=true; })
+      .catch(err=>{ console.error(err); showError(err); });
+    if('serviceWorker' in navigator){
+      const registerSw=src=>navigator.serviceWorker.register(src).then(()=>{
+        navigator.serviceWorker.addEventListener('controllerchange',()=>location.reload());
       });
+      registerSw(addVersion('sw.js'))
+        .catch(err=>{ console.error(err); return registerSw('sw.js'); })
+        .catch(err=>{ console.error(err); showError(err); });
     }
   }catch(e){showError(e);}
 })();


### PR DESCRIPTION
## Summary
- ensure game loop always starts and hide loader after first rendered frame
- add startup watchdog and versioned script fallback
- surface load and init errors via overlay

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8da2dd0408325b9bcc61ee9d4159e