### PR TITLE
feat: add yawn emote

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.0.6';
+self.GAME_VERSION = '0.0.7';


### PR DESCRIPTION
## Summary
- bump version to v0.0.7
- add idle yawn animation with anticipaton, peak, and closing phases
- interrupt yawning on input and randomize idle/cooldown timers

## Testing
- `node --check game.js`
- `node --check version.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8e56c3ec883258d080723c8e2986a