### PR TITLE
feat: add speed telemetry and tuning

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.0.7';
+self.GAME_VERSION = '0.0.8';


### PR DESCRIPTION
## Summary
- bump version to v0.0.8
- show instantaneous, max, and average speed on HUD with 1200px gate timer
- tune horizontal movement constants (maxRunSpeed 6→21, runAccel 6→18, runDecel 0.85→0.7)
- add dynamic camera look-ahead based on player velocity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eb59fbfc8325a4d27ae69f1e3dba