### PR TITLE
Tune difficulty speed factors and bump v0.1.2

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,7 +13,7 @@ let debug = false;
 let paused = true;
 
 const DIFF_KEY = 'platformer.difficulty.v1';
-const DIFF_FACTORS = { Easy:1.00, Normal:1.10, Hard:1.20 };
+const DIFF_FACTORS = { Easy:1.00, Normal:1.30, Hard:1.60 };
 
 const base = {
   maxRunSpeed: 6.0 * 3.5, // allow up to ×4 if needed
@@ -380,7 +380,7 @@ function updateCoins(dt){
 function updateCamera(dt){
   const p = world.player;
   const vInst = p.vx*10;
-  const lookAhead = Math.min(Math.max(Math.abs(vInst)*0.18,80),220) * p.dir;
+  const lookAhead = Math.min(Math.max(Math.abs(vInst)*0.18,80),260) * p.dir;
   const targetX = p.x + p.w/2 - viewWidth/2 + lookAhead;
   const targetY = p.y + p.h/2 - viewHeight/2;
   world.camera.x += (targetX - world.camera.x)*0.15;

--- a/index.html
+++ b/index.html
@@ -71,9 +71,9 @@ window.onunhandledrejection=e=>{showError(e.reason);};
   </div>
   <div id="menu-settings" class="menu-screen hidden">
     <div class="difficulty-options">
-      <label><input type="radio" name="difficulty" value="Easy"> Easy</label>
-      <label><input type="radio" name="difficulty" value="Normal"> Normal</label>
-      <label><input type="radio" name="difficulty" value="Hard"> Hard</label>
+      <label><input type="radio" name="difficulty" value="Easy"> Easy (x1.00)</label>
+      <label><input type="radio" name="difficulty" value="Normal"> Normal (x1.30)</label>
+      <label><input type="radio" name="difficulty" value="Hard"> Hard (x1.60)</label>
     </div>
     <button id="btn-back" class="menu-btn">BACK</button>
   </div>

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.1';
+self.GAME_VERSION = '0.1.2';


### PR DESCRIPTION
## Summary
- raise Normal and Hard difficulty multipliers to 1.30x and 1.60x
- scale horizontal movement from base values and expand camera look-ahead cap
- show new multipliers in settings menu and bump version to v0.1.2

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8f341eaf8832581878e95aa5e33c7