### PR TITLE
Fix input drift and add debug HUD

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.3';
+self.GAME_VERSION = '0.1.4';


### PR DESCRIPTION
## Summary
- unify keyboard input through shared left/right state and per-frame axis computation
- apply strict friction and stop clamps to remove lingering motion
- add F1 mini-HUD with last input event and bump version to v0.1.4

## Testing
- `npm test` *(fails: no package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8f6d5edc48325841dbff47921328c