### PR TITLE
feat: adjust difficulty scaling and bump version

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,7 +13,8 @@ let debug = false;
 let paused = true;
 
 const DIFF_KEY = 'platformer.difficulty.v1';
-const DIFF_FACTORS = { Easy:1.00, Normal:1.30, Hard:1.60 };
+// Difficulty multipliers relative to Easy base values
+const DIFF_FACTORS = { Easy:1.00, Normal:1.60, Hard:2.20 };
 
 const base = {
   maxRunSpeed: 6.0 * 3.5, // allow up to ×4 if needed

--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@ window.onunhandledrejection=e=>{showError(e.reason);};
   <div id="menu-settings" class="menu-screen hidden">
     <div class="difficulty-options">
       <label><input type="radio" name="difficulty" value="Easy"> Easy (x1.00)</label>
-      <label><input type="radio" name="difficulty" value="Normal"> Normal (x1.30)</label>
-      <label><input type="radio" name="difficulty" value="Hard"> Hard (x1.60)</label>
+      <label><input type="radio" name="difficulty" value="Normal"> Normal (x1.60)</label>
+      <label><input type="radio" name="difficulty" value="Hard"> Hard (x2.20)</label>
     </div>
     <button id="btn-back" class="menu-btn">BACK</button>
   </div>

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.4';
+self.GAME_VERSION = '0.1.5';


### PR DESCRIPTION
## Summary
- expand difficulty multipliers to Easy x1.00, Normal x1.60, Hard x2.20
- display new multipliers in settings and gameplay
- bump game version to v0.1.5

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f8f1ca50832594eb12077269b479