### PR TITLE
v0.1.7: air release damping

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.6';
+self.GAME_VERSION = '0.1.7';


### PR DESCRIPTION
## Summary
- Add air-release cut that halves aerial horizontal velocity and begins time-based damping
- Stop damping 50ms after new directional input and reset damping upon landing
- Update version to v0.1.7

## Testing
- `node --check game.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ff3890a48325b29dafebccabf157