### PR TITLE
Expand debug grid to full world with fallback

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.12';
+self.GAME_VERSION = '0.1.13';


### PR DESCRIPTION
## Summary
- detect world bounds from level content and add 1440-tile fallback span
- rebuild debug grid to cover extended X/Y ranges and expose world mode in HUD
- bump version to v0.1.13

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b94b1b1b8c832594c21158fbf5e38f