### PR TITLE
feat: stabilize grid across zoom levels

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.16';
+self.GAME_VERSION = '0.1.17';


### PR DESCRIPTION
## Summary
- use effective scale combining DPR and page zoom for grid rendering
- ensure grid lines snap to device pixels and stay visible at all zoom levels
- show DPR, zoom, and effective scale in temporary HUD and bump version to v0.1.17

## Testing
- `npm test`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b953f9da308325ba7451a4a2d3576e