### PR TITLE
feat: HUD shows player and camera coordinates

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.25';
+self.GAME_VERSION = '0.1.26';


### PR DESCRIPTION
## Summary
- show player and camera positions and framing info in HUD
- toggle extended HUD details with F3 and store the state
- bump version to v0.1.26

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b96d414a3c8325b2516585d57f597b