### PR TITLE
v0.1.29: adjust vertical camera framing

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.28';
+self.GAME_VERSION = '0.1.29';


### PR DESCRIPTION
## Summary
- position player 5 tiles from bottom and smooth camera Y with clamping
- add adjustable FRAMING_Y_TILES and HUD feedback
- bump version to v0.1.29

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9746493e88325b0bbf844f1678933