### PR TITLE
feat: add vertical camera dead-zone and smoothing

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.30';
+self.GAME_VERSION = '0.1.31';


### PR DESCRIPTION
## Summary
- make camera follow player on Y with dead-zone and smoothing
- show camera metrics in HUD and optional dead-zone overlay
- bump version to v0.1.31

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b97acaa53083259693b43bc61f788c