### PR TITLE
Fix vertical camera follow when falling

### DIFF
--- a/game.js
+++ b/game.js
@@ -879,8 +879,13 @@ function updateCamera(dt){
   const minCamY = worldMinY;
   const maxCamY = Math.max(worldMinY, worldMaxY - viewHeight);
   let clampY = 'none';
-  if(camY < minCamY){ camY = minCamY; clampY = 'top'; }
-  else if(camY > maxCamY){ camY = maxCamY; clampY = 'bottom'; }
+  if(camY < minCamY){
+    camY = minCamY;
+    clampY = 'top';
+  }else if(camY > maxCamY && playerY <= worldMaxY){
+    camY = maxCamY;
+    clampY = 'bottom';
+  }
 
   world.camera.y = camY;
   world.camera.framingYTiles = settings.framingTiles;


### PR DESCRIPTION
## Summary
- Allow camera to continue following the player vertically when falling below the level

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d1a21ec83258598171b803ff37c