### PR TITLE
Center world vertically by default

### DIFF
--- a/game.js
+++ b/game.js
@@ -37,7 +37,7 @@ const settings = {
     lerpPerSec: 8.0
   }
 };
-if(!(settings.framingTiles >= 0 && settings.framingTiles <= 8)) settings.framingTiles = 5;
+if(!(settings.framingTiles >= 0 && settings.framingTiles <= 8)) settings.framingTiles = 0;
 
 const base = {
   maxRunSpeed: 6.0 * 3.5 * 2.20, // rebased from previous Hard


### PR DESCRIPTION
## Summary
- Center the game world by setting default framing tiles to zero

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e7ada588325a3bbff8b009975b6