### PR TITLE
Allow downward camera framing

### DIFF
--- a/game.js
+++ b/game.js
@@ -37,7 +37,7 @@ const settings = {
     lerpPerSec: 8.0
   }
 };
-if(!(settings.framingTiles >= 0 && settings.framingTiles <= 8)) settings.framingTiles = 0;
+if(!(settings.framingTiles >= -8 && settings.framingTiles <= 8)) settings.framingTiles = -3;
 
 const base = {
   maxRunSpeed: 6.0 * 3.5 * 2.20, // rebased from previous Hard
@@ -530,7 +530,7 @@ function init(){
     if(e.code==='F2'){ toggleGrid(); e.preventDefault(); return; }
     if(e.code==='F4'){ toggleGridStep(); e.preventDefault(); return; }
     if(e.code==='KeyG'){ deadZoneDebug=!deadZoneDebug; e.preventDefault(); return; }
-    if(e.code==='BracketLeft'){ settings.framingTiles=Math.max(0,settings.framingTiles-1); world.camera.framingYTiles=settings.framingTiles; localStorage.setItem(SETTINGS_FRAMING_KEY,settings.framingTiles); e.preventDefault(); return; }
+    if(e.code==='BracketLeft'){ settings.framingTiles=Math.max(-8,settings.framingTiles-1); world.camera.framingYTiles=settings.framingTiles; localStorage.setItem(SETTINGS_FRAMING_KEY,settings.framingTiles); e.preventDefault(); return; }
     if(e.code==='BracketRight'){ settings.framingTiles=Math.min(8,settings.framingTiles+1); world.camera.framingYTiles=settings.framingTiles; localStorage.setItem(SETTINGS_FRAMING_KEY,settings.framingTiles); e.preventDefault(); return; }
     if(['ArrowLeft','ArrowRight','ArrowUp','ArrowDown','Space'].includes(e.code)) e.preventDefault();
     if(e.code==='ArrowLeft'||e.code==='KeyA') keyLeft=true;

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@ window.onunhandledrejection=e=>{showError(e.reason);};
       <label><input type="radio" name="framing" value="5"> Low (+5)</label>
       <label><input type="radio" name="framing" value="3"> Mid (+3)</label>
       <label><input type="radio" name="framing" value="0"> Center (+0)</label>
+      <label><input type="radio" name="framing" value="-3"> High (-3)</label>
     </div>
     <button id="btn-back" class="menu-btn">BACK</button>
   </div>


### PR DESCRIPTION
## Summary
- Add "High (-3)" framing option to settings menu
- Default camera framing to -3 tiles and allow negative offsets

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9813f3ed88325bb40e1b496483214