### PR TITLE
Adjust camera framing with persistent setting

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.33';
+self.GAME_VERSION = '0.1.34';


### PR DESCRIPTION
## Summary
- Allow camera offset without hitting top clamp by adding configurable top padding and ensuring desired Y is reachable
- Persist `framingTiles` in localStorage and expose framing stats in HUD
- Bump version to v0.1.34

## Testing
- `node --check game.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b99226559483258a3bff76bd2e70ef