### PR TITLE
feat: sky gradient background and version bump

### DIFF
--- a/game.js
+++ b/game.js
@@ -960,7 +960,11 @@ function render(){
   const bgOffset = snap(camX*0.2);
   const sd = canvasScale * dpr;
   ctx.setTransform(1,0,0,1,0,0);
-  ctx.clearRect(0,0,canvas.width,canvas.height);
+  const g = ctx.createLinearGradient(0,0,0,canvas.height);
+  g.addColorStop(0,'#4a90e2');
+  g.addColorStop(1,'#87ceeb');
+  ctx.fillStyle = g;
+  ctx.fillRect(0,0,canvas.width,canvas.height);
   ctx.setTransform(sd,0,0,sd,offsetX*dpr,offsetY*dpr);
   drawBackground(bgOffset);
   renderGrid(ctx, camX, camY);

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
-html,body{margin:0;height:100%;background:#0e0f14;color:#eee;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial}
+html,body{margin:0;height:100%;background:linear-gradient(#4a90e2,#87ceeb);color:#eee;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;overflow:hidden}
+#loading-screen{background:transparent}
 #game{display:block}
 #error-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);color:#fff;padding:16px;white-space:pre-wrap;overflow:auto}
 #menu{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.8);z-index:10}

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.34';
+self.GAME_VERSION = '0.1.35';


### PR DESCRIPTION
## Summary
- Fill entire canvas with a sky gradient so letterboxed areas match the game background
- Add CSS gradient fallback with transparent loading screen
- Bump version to v0.1.35 and display in HUD/title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9956e4aec8325bf6b38ad60c739f1