### PR TITLE
Extend ground platform

### DIFF
--- a/game.js
+++ b/game.js
@@ -616,6 +616,12 @@ function init(){
     {x:520,y:250,w:150,h:20},
     {x:710,y:180,w:120,h:20}
   ]);
+  const ground = world.platforms[0];
+  const baseTiles = ground.w / tileSize;
+  const extendLeftTiles = 2 * baseTiles;
+  const extendRightTiles = 10 * baseTiles;
+  ground.x -= extendLeftTiles * tileSize;
+  ground.w += (extendLeftTiles + extendRightTiles) * tileSize;
   world.coins = asArray([
     {x:230,y:190,t:0,collected:false},
     {x:410,y:120,t:0,collected:false},

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.36';
+self.GAME_VERSION = '0.1.37';


### PR DESCRIPTION
## Summary
- extend base ground platform dynamically using tile-based calculations
- bump game version to 0.1.37

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b3dab9c8325b4fa088f30d4390f