### PR TITLE
Clamp player to camera edges without padding

### DIFF
--- a/game.js
+++ b/game.js
@@ -8,7 +8,6 @@ const VIRTUAL_HEIGHT = 810;
 const tileSize = 60;
 
 const CLAMP_PLAYER_TO_CAMERA_X = true;
-const CAM_CLAMP_PAD = 2;
 
 const PARALLAX_ENABLED = true;
 const parallax = { segments:{}, clouds:[] };
@@ -672,7 +671,7 @@ function loop(t){
     if(acc>dt) acc=dt;
     updateCamera(delta/1000);
     if(CLAMP_PLAYER_TO_CAMERA_X){
-      world.camera.clampX = clampPlayerToCameraX();
+      clampPlayerToCameraX();
     }else{
       world.camera.clampX = 'none';
     }
@@ -974,21 +973,23 @@ function updateCamera(dt){
 function clampPlayerToCameraX(){
   const p = world.player;
   const camX = world.camera.x;
-  const left = camX + CAM_CLAMP_PAD;
-  const right = camX + viewWidth - p.w - CAM_CLAMP_PAD;
+  const left = camX;
+  const right = camX + viewWidth - p.w;
   if(p.x < left){
     p.x = left;
     p.vx = Math.max(0, p.vx);
     p.releaseCut = false;
-    return 'left';
+    world.camera.clampX = 'left';
+    return;
   }
   if(p.x > right){
     p.x = right;
     p.vx = Math.min(0, p.vx);
     p.releaseCut = false;
-    return 'right';
+    world.camera.clampX = 'right';
+    return;
   }
-  return 'none';
+  world.camera.clampX = 'none';
 }
 
 function rectIntersect(a,b){

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.40';
+self.GAME_VERSION = '0.1.41';


### PR DESCRIPTION
## Summary
- Remove camera clamp padding and clamp player exactly to visible bounds
- Report X clamp status in HUD and track via `world.camera.clampX`
- Bump version to 0.1.41

## Testing
- `node --version`
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9ad233a3483259cb9cd3de9ff9631