### PR TITLE
Add main corridor platform and upward generator

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.46';
+self.GAME_VERSION = '0.1.47';


### PR DESCRIPTION
## Summary
- define platform corridor settings and platform height constant
- restrict jumps to single-tile upward moves
- build long main ground platform with extra platforms spawned above
- bump game version

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9c41f6bd88325b85b112c3149f9f2