### PR TITLE
chore(coins): lower coins for run-through pickup; bump patch

### DIFF
--- a/game.js
+++ b/game.js
@@ -463,7 +463,7 @@ function generateLevel(seed, layers=4){
   const rightBound = anchorX + PLATFORM_GEN.mainForwardTiles * tile;
   const ground = {x:leftBound, y:baseGroundY, w:rightBound - leftBound, h, level:0};
   world.platforms.push(ground);
-  world.coins.push({x:anchorX + w/2, y:ground.y - 1.2*tile, t:0, collected:false});
+  world.coins.push({x:anchorX + w/2, y:ground.y - tile/3, t:0, collected:false});
 
   const mainYTile = Math.round(baseGroundY / tile);
   const bandBottom = mainYTile + PLATFORM_GEN.bandBottomOffset;
@@ -516,7 +516,7 @@ function generateLevel(seed, layers=4){
       if(!headClearPrev) { placed = false; break; }
       if(!hasHeadClearance(pl.x, pl.y, pl.w)) continue;
       world.platforms.push(pl);
-      world.coins.push({x:pl.x + pl.w/2, y:pl.y - 1.2*tile, t:0, collected:false});
+      world.coins.push({x:pl.x + pl.w/2, y:pl.y - tile/3, t:0, collected:false});
       prev = {x:pl.x, yTile:newY, w:pl.w};
       currY = newY;
       placed = true;

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.48';
+self.GAME_VERSION = '0.1.49';


### PR DESCRIPTION
## Summary
- Lower coin placements so players can grab them while running.
- Bump patch version.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba885fa2888325a577cdb514d24e04