### PR TITLE
feat(player): add Shift dash (2 tiles); bump patch

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.50';
+self.GAME_VERSION = '0.1.51';


### PR DESCRIPTION
## Summary
- add configurable Shift dash for the player, including air dash and cooldown
- bump version to 0.1.51

## Testing
- `node --check game.js`
- `node --check version.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba9741c01083259f027e97deb2c019