### PR TITLE
feat(vfx): dash trail and swoosh

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = '0.1.51';
+self.GAME_VERSION = '0.1.52';


### PR DESCRIPTION
## Summary
- add afterimage trail, speed lines, dust, camera kick/shake and dash swoosh
- expose dash VFX parameters and events
- bump patch version to 0.1.52

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9d3515fc8325bb377ec455c1f780