### PR TITLE
feat(menu): Esc pause menu + rename Start→New game; new game resets state; bump patch

### DIFF
--- a/game.js
+++ b/game.js
@@ -2361,14 +2361,27 @@ function setupMenu() {
     settingsMenu.classList.toggle("hidden", screen !== "settings");
     menu.style.display = "flex";
     paused = true;
+    if (audioCtx) audioCtx.suspend();
   };
 
-  startBtn.addEventListener("click", () => {
-    applyDifficulty(currentDifficulty);
-    resetInput();
+  const hide = () => {
     menu.style.display = "none";
     paused = false;
-  });
+    if (audioCtx) audioCtx.resume();
+  };
+
+  const newGame = () => {
+    applyDifficulty(currentDifficulty);
+    score = 0;
+    levelSeed = Date.now();
+    measureReachability();
+    generateLevel(levelSeed, 4);
+    resetPlayerToGround();
+    resetInput();
+    hide();
+  };
+
+  startBtn.addEventListener("click", newGame);
   settingsBtn.addEventListener("click", () => show("settings"));
   backBtn.addEventListener("click", () => show("main"));
 
@@ -2388,10 +2401,10 @@ function setupMenu() {
     if (menu.style.display !== "none") {
       if (!mainMenu.classList.contains("hidden")) {
         if (e.code === "Enter") {
-          applyDifficulty(currentDifficulty);
-          resetInput();
-          menu.style.display = "none";
-          paused = false;
+          newGame();
+          e.preventDefault();
+        } else if (e.code === "Escape") {
+          hide();
           e.preventDefault();
         }
       } else {
@@ -2400,6 +2413,9 @@ function setupMenu() {
           e.preventDefault();
         }
       }
+    } else if (e.code === "Escape") {
+      show("main");
+      e.preventDefault();
     }
   });
 

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
     </div>
     <div id="menu">
       <div id="menu-main" class="menu-screen">
-        <button id="btn-start" class="menu-btn">START</button>
+        <button id="btn-start" class="menu-btn">NEW GAME</button>
         <button id="btn-settings" class="menu-btn">SETTINGS</button>
       </div>
       <div id="menu-settings" class="menu-screen hidden">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platformer",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platformer",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "devDependencies": {
         "eslint": "^8.57.0",
         "stylelint": "^15.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformer",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint styles.css",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = "0.1.54";
+self.GAME_VERSION = "0.1.55";


### PR DESCRIPTION
## Summary
- allow toggling the menu with Escape and pause/resume audio
- rename Start button to New game and reset state when starting
- bump version to 0.1.55

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa7c15fa08325b5127d274a0e440c