### PR TITLE
Optimize grid rendering via offscreen cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformer",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint styles.css",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = "0.1.57";
+self.GAME_VERSION = "0.1.58";


### PR DESCRIPTION
## Summary
- Cache grid drawing in an offscreen canvas and redraw only when tile size, scale, step, or camera tile changes for smoother rendering【F:game.js†L257-L264】【F:game.js†L1018-L1086】【F:game.js†L2127-L2154】
- Map **G** key to toggle grid overlay and move dead-zone debug to **F2**【F:game.js†L1196-L1209】
- Bump version to 0.1.58【F:package.json†L1-L5】【F:version.js†L1-L1】

## Testing
- `npm test`【f8fe6a†L1-L16】

------
https://chatgpt.com/codex/tasks/task_e_68baf525f38883259558f2bda1744679