### PR TITLE
feat(level): thicken main platform and clamp camera at new gap

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,6 +13,8 @@ const PLATFORM_HEIGHT = 20;
 
 const CLAMP_PLAYER_TO_CAMERA_X = true;
 
+let cameraRightClamp = "gapStart";
+
 let parallaxEnabled = true;
 const parallax = { segments: {}, clouds: [] };
 
@@ -234,6 +236,8 @@ const world = {
   coins: [],
   player: null,
   spawnCenterX: 0,
+  gapStartX: 0,
+  newPlatformEnd: 0,
   camera: {
     x: 0,
     y: 0,
@@ -279,7 +283,7 @@ const lastGen = { seed: 0, layers: 0, stepX: 0, stepY: 0 };
 const PLATFORM_GEN = {
   mainBackwardTiles: 20,
   mainForwardTiles: 300,
-  mainThicknessTiles: 3,
+  mainThicknessTiles: 60,
   platformLengthTiles: 3,
   minDx: 2,
   bandBottomOffset: 2,
@@ -874,6 +878,17 @@ function generateLevel(seed, layers = 4) {
     t: 0,
     collected: false,
   });
+
+  world.gapStartX = ground.x + ground.w;
+  const endPlatform = {
+    x: world.gapStartX + tile,
+    y: baseGroundY,
+    w: 20 * tile,
+    h: platformH,
+    level: 0,
+  };
+  world.platforms.push(endPlatform);
+  world.newPlatformEnd = endPlatform.x + endPlatform.w;
 
   const mainYTile = Math.round(baseGroundY / tile);
   const bandBottom = mainYTile + PLATFORM_GEN.bandBottomOffset;
@@ -1791,7 +1806,12 @@ function updateCamera(dt) {
     worldStartX,
     world.spawnCenterX - viewWidth / 2,
   );
-  const maxCamX = Math.max(worldStartX, worldEndX - viewWidth);
+  let clampRight = worldEndX;
+  if (cameraRightClamp === "gapStart")
+    clampRight = Math.min(clampRight, world.gapStartX);
+  else if (cameraRightClamp === "newPlatformEnd")
+    clampRight = Math.min(clampRight, world.newPlatformEnd);
+  const maxCamX = Math.max(worldStartX, clampRight - viewWidth);
   let camX = Math.min(Math.max(desiredX, minCamXSpawn), maxCamX);
   world.camera.x += (camX - world.camera.x) * 0.15;
   if (Math.abs(camX - world.camera.x) < 0.5) world.camera.x = camX;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platformer",
-  "version": "0.1.57",
+  "version": "0.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platformer",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "devDependencies": {
         "eslint": "^8.57.1",
         "stylelint": "^15.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformer",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint styles.css",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = "0.1.58";
+self.GAME_VERSION = "0.1.59";


### PR DESCRIPTION
## Summary
- Thicken main platform 20 tiles downward and extend level with a 1-tile gap and 20-tile platform
- Clamp camera so its right edge stops at the gap start
- Bump patch version to 0.1.59

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf9cc53cc8325bc5f56ff1122d52c