### PR TITLE
Clamp camera at second main platform end

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,7 +13,7 @@ const PLATFORM_HEIGHT = 20;
 
 const CLAMP_PLAYER_TO_CAMERA_X = true;
 
-let cameraRightClamp = "gapStart";
+let cameraRightClamp = "secondMainEnd";
 
 let parallaxEnabled = true;
 const parallax = { segments: {}, clouds: [] };
@@ -238,6 +238,7 @@ const world = {
   spawnCenterX: 0,
   gapStartX: 0,
   newPlatformEnd: 0,
+  secondMainRightX: 0,
   camera: {
     x: 0,
     y: 0,
@@ -889,6 +890,7 @@ function generateLevel(seed, layers = 4) {
   };
   world.platforms.push(endPlatform);
   world.newPlatformEnd = endPlatform.x + endPlatform.w;
+  world.secondMainRightX = endPlatform.x + endPlatform.w;
 
   const mainYTile = Math.round(baseGroundY / tile);
   const bandBottom = mainYTile + PLATFORM_GEN.bandBottomOffset;
@@ -1811,6 +1813,8 @@ function updateCamera(dt) {
     clampRight = Math.min(clampRight, world.gapStartX);
   else if (cameraRightClamp === "newPlatformEnd")
     clampRight = Math.min(clampRight, world.newPlatformEnd);
+  else if (cameraRightClamp === "secondMainEnd")
+    clampRight = Math.min(clampRight, world.secondMainRightX);
   const maxCamX = Math.max(worldStartX, clampRight - viewWidth);
   let camX = Math.min(Math.max(desiredX, minCamXSpawn), maxCamX);
   world.camera.x += (camX - world.camera.x) * 0.15;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platformer",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platformer",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "devDependencies": {
         "eslint": "^8.57.1",
         "stylelint": "^15.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformer",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint styles.css",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = "0.1.59";
+self.GAME_VERSION = "0.1.60";


### PR DESCRIPTION
## Summary
- Add `secondMainEnd` camera clamp using `secondMainRightX` so the viewport's right edge can't pass the second main platform
- Default cameraRightClamp to `secondMainEnd`
- Bump version to 0.1.60

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bafd05d9e88325813506ff4d11e46e