### PR TITLE
feat: swap bridge for teleport after collecting all coins

### DIFF
--- a/game.js
+++ b/game.js
@@ -896,7 +896,7 @@ function generateLevel(seed, layers = 4) {
     x: world.gapStartX,
     y: baseGroundY,
     w: tile,
-    h: groundH,
+    h: tile,
     level: 0,
   };
   world.platforms.push(bridge);
@@ -1829,12 +1829,7 @@ function updateBridgeTeleport() {
         const idx = world.platforms.indexOf(b);
         if (idx >= 0) world.platforms.splice(idx, 1);
         world.gapBridge = null;
-        world.teleport = {
-          x: b.x,
-          y: b.y - tileSize * 2,
-          w: tileSize,
-          h: tileSize * 2,
-        };
+        world.teleport = { x: b.x, y: b.y, w: b.w, h: b.h };
         computeWorldBounds();
         rebuildGrid();
       }
@@ -1847,6 +1842,7 @@ function updateBridgeTeleport() {
     p.vx = 0;
     p.vy = 0;
     p.onGround = false;
+    world.spawnCenterX = p.x + p.w / 2;
     computeWorldBounds();
     rebuildGrid();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platformer",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platformer",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "devDependencies": {
         "eslint": "^8.57.1",
         "stylelint": "^15.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformer",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint styles.css",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = "0.1.62";
+self.GAME_VERSION = "0.1.63";


### PR DESCRIPTION
## Summary
- convert 1-tile gap bridge into teleport once all coins are collected
- teleport returns player to start without altering camera clamp
- bump version to 0.1.63

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0af7c2288325b9b878dc4edbd4aa