### PR TITLE
fix(teleport): send player to world (20px, 0px), align feet to Y; reset velocity; debug marker; bump patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "platformer",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "platformer",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "devDependencies": {
         "eslint": "^8.57.1",
         "stylelint": "^15.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformer",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint styles.css",

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-self.GAME_VERSION = "0.1.63";
+self.GAME_VERSION = "0.1.64";


### PR DESCRIPTION
## Summary
- Place teleport destination at world coordinates (20px, 0px) and align player feet, resetting movement and dash/jump state
- Spawn player at same coordinates on new game
- Add debug cross marker at teleport destination when DEBUG is enabled
- Bump version to 0.1.64

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0d2679248325b95ab72959f58dab