### PR TITLE
fix: ensure menu elements exist

### DIFF
--- a/levels/level1/game.js
+++ b/levels/level1/game.js
@@ -2643,7 +2643,29 @@ function downloadSpikes() {
 }
 
 function setupMenu() {
-  const menu = document.getElementById("menu");
+  let menu = document.getElementById("menu");
+  if (!menu) {
+    menu = document.createElement("div");
+    menu.id = "menu";
+    menu.innerHTML = `
+      <div id="menu-main" class="menu-screen">
+        <button id="btn-start" class="menu-btn">Start</button>
+        <button id="btn-settings" class="menu-btn">Settings</button>
+      </div>
+      <div id="menu-settings" class="menu-screen hidden">
+        <div class="difficulty-options">
+          ${Object.keys(DIFF_FACTORS)
+            .map(
+              (d) =>
+                `<label><input type="radio" name="difficulty" value="${d}">${d}</label>`,
+            )
+            .join("")}
+        </div>
+        <button id="btn-back" class="menu-btn">Back</button>
+      </div>
+    `;
+    document.body.appendChild(menu);
+  }
   const mainMenu = document.getElementById("menu-main");
   const settingsMenu = document.getElementById("menu-settings");
   const startBtn = document.getElementById("btn-start");


### PR DESCRIPTION
## Summary
- create missing level 1 menu elements programmatically
- wire up start and settings controls to avoid null references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3921e4c0832596eae2cd12b0f5f3