### PR TITLE
Hide loading screen on menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,8 @@
           window.bootLevel = (level) => {
             startWatchdog();
             setupPause();
+            const loader = document.getElementById("loading-screen");
+            if (loader) loader.style.display = "flex";
             const levelPath = `levels/level${level}`;
             link.href = addVersion(`${levelPath}/styles.css`);
             loadScript(addVersion(`${levelPath}/game.js`))

--- a/ui/menu/index.js
+++ b/ui/menu/index.js
@@ -3,6 +3,9 @@
   const starfield = initStarfield(canvas);
   starfield.start();
 
+  const loader = document.getElementById('loading-screen');
+  if (loader) loader.style.display = 'none';
+
   const menu = document.createElement('div');
   menu.id = 'main-menu';
   menu.innerHTML = `


### PR DESCRIPTION
## Summary
- Hide loading overlay once menu is displayed
- Show loading overlay when booting levels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3af348ec832582bbb4d9e9f9852d