### PR TITLE
Stop menu starfield from resuming during levels after tab switch

### DIFF
--- a/ui/menu/index.js
+++ b/ui/menu/index.js
@@ -72,7 +72,7 @@
   function startLevel(level) {
     active = false;
     document.removeEventListener('keydown', onKeyDown);
-    starfield.stop();
+    starfield.dispose();
     menu.remove();
     bootLevel(level);
   }

--- a/ui/menu/starfield.js
+++ b/ui/menu/starfield.js
@@ -71,12 +71,18 @@
     }
 
     window.addEventListener('resize', resize);
-    document.addEventListener('visibilitychange', () => {
+    const onVis = () => {
       if (document.hidden) stop();
       else start();
-    });
+    };
+    document.addEventListener('visibilitychange', onVis);
     resize();
-    return { start, stop, resize };
+    function dispose() {
+      stop();
+      window.removeEventListener('resize', resize);
+      document.removeEventListener('visibilitychange', onVis);
+    }
+    return { start, stop, resize, dispose };
   }
   global.initStarfield = initStarfield;
 })(self);


### PR DESCRIPTION
## Summary
- dispose starfield listeners when starting a level
- prevent starfield from restarting on tab visibility changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4201d6148325bc84a0332fbbcb22